### PR TITLE
add test a solidity event tutorial files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.env
+node_modules
+.DS_Store
+/dist
+
+# Compiler files
+cache/
+out/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# test-an-event-with-foundry
-How to test a solidity event within a Hedera smart contract using Foundry.
+# How to Test a Solidity Event with Foundry 
+
+Foundry supports the use of cheatcodes. Cheatcodes allow you to go beyond testing the outputs of your smart contracts. They allow developers to manipulate the state of the blockchain, test for reverts, 
+and events. In this tutorial, we will focus on the cheatcode `vm.expectEmit` to test a solidity event.
+
+## What you will accomplish
+
+- ✅ Use the vm.expectEmit Cheatcode
+- ✅ Test a Solidity event
+
+
+---
+
+## Get started
+
+The repo, github.com/hedera-dev/test-an-event-with-foundry, is intended to be used alongside this [tutorial](docs.hedera.com).

--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ and events. In this tutorial, we will focus on the cheatcode `vm.expectEmit` to 
 ## Get started
 
 The repo, github.com/hedera-dev/test-an-event-with-foundry, is intended to be used alongside this [tutorial](docs.hedera.com).
+
+> [!IMPORTANT]  
+> This project has submodules. You  must initialize the submodule configuration file and fetch all submodule data from the project. To do this run the following command:
+
+```shell
+git clone --recurse-submodules git@github.com:hedera-dev/test-an-event-with-foundry.git
+```

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,14 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+
+# Step 5
+gas_reports = ["TodoList"]
+# /*...*/
+
+[rpc_endpoints]
+h_testnet = "https://testnet.hashio.io/api"
+h_mainnet = "https://mainnet.hashio.io/api"
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,10 +3,6 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 
-# Step 5
-gas_reports = ["TodoList"]
-# /*...*/
-
 [rpc_endpoints]
 h_testnet = "https://testnet.hashio.io/api"
 h_mainnet = "https://mainnet.hashio.io/api"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "setup-foundry-and-write-basic-unit-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "bin": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@hashgraph/sdk": "^2.39.0",
+    "dotenv": "^16.1.4"
+  }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+forge-std/=lib/forge-std/src/

--- a/src/TodoList.sol
+++ b/src/TodoList.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+struct Todo {
+  uint id;
+  string description;
+  bool completed;
+}
+
+contract TodoList {
+  uint256 public numberOfTodos = 0;
+  
+  event CreateTodo(address indexed creator, uint256 indexed todoIndex, string description);
+
+  mapping(uint => Todo) public todos;
+
+  function createTodo(address creator, string memory description) public returns (uint256) {
+    numberOfTodos++;
+    todos[numberOfTodos] = Todo(numberOfTodos, description, false);
+    emit CreateTodo(creator, numberOfTodos, description);
+    return numberOfTodos;
+  }
+
+  function getTodoById(uint256 id) public view returns (Todo memory) {
+    return todos[id];
+  }
+
+  function toggleCompleted(uint _id) public {
+    Todo memory _todo = todos[_id];
+    _todo.completed = !_todo.completed;
+    todos[_id] = _todo;
+  }
+
+  function getNumberOfTodos() public view returns (uint256) {
+      return numberOfTodos;
+  }
+}

--- a/test/TodoList.t.sol
+++ b/test/TodoList.t.sol
@@ -6,7 +6,7 @@ import "src/TodoList.sol";
 
 contract TodoListTest is Test {
   TodoList public todoList;
-  // Step (1) - Define the exepcted event
+  // Step (1) - Define the expected event
    /* ... */
 
       function setUp() public {
@@ -29,10 +29,10 @@ contract TodoListTest is Test {
     // Step (3) - Specify the event data to test
     /* ... */
 
-    // Step (4) - emit the expected event
+    // Step (4) - Emit the expected event
     /* ... */
 
-    // Step (5) - execute the contract function that emits the event
+    // Step (5) - Execute the contract function that emits the event
     /* ... */
    }
 }

--- a/test/TodoList.t.sol
+++ b/test/TodoList.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "src/TodoList.sol";
+
+contract TodoListTest is Test {
+  TodoList public todoList;
+  // Step (1) - Define the exepcted event
+   /* ... */
+
+      function setUp() public {
+        todoList = new TodoList();
+    }  
+
+   function test_createTodo_returnsNumberOfTodosIncrementedByOne() public {
+
+     uint256 numberOfTodosBefore = todoList.getNumberOfTodos();
+
+     uint256 numberOfTodosAfter = todoList.createTodo(address(this), "A new todo for you!");
+
+     assertEq(numberOfTodosAfter, (numberOfTodosBefore + 1), "create todo test");
+   }
+
+   function test_emit_createTodoEvent() public {
+    // Step (2) - Get the current number of todos
+    /* ... */
+    
+    // Step (3) - Specify the event data to test
+    /* ... */
+
+    // Step (4) - emit the expected event
+    /* ... */
+
+    // Step (5) - execute the contract function that emits the event
+    /* ... */
+   }
+}


### PR DESCRIPTION
### Description
 This short tutorial teaches developers how to test a solidity event using foundry cheatcodes.
 The tutorial text is located here : https://github.com/hedera-dev/preview-hedera-docs/pull/12/commits/3cfa42636ede1d30b32612452edc8d2d1aebdacb

### What is being added
Foundry manages dependencies through gitsubmodules so a `.gitsubmodule` file is added along with the directory, `lib`, that contains the submodules.
Readme.md file which introduces the tutorial and provides a link to the tutorial on docs.hedera.com
A `src` folder which is where foundry looks for smart contracts
The `TodoList.sol` contract which we will be testing.
A `test` folder to house our solidity tests
The `TodoList.t.sol` test contract.
A `package.json` file which has the hashgraph SDK JS

